### PR TITLE
Add SQL support and add helper functions.

### DIFF
--- a/kracked/db.py
+++ b/kracked/db.py
@@ -93,7 +93,7 @@ class KrackedDB:
                 # of the SQL table's columns.
                 raise ValueError("Depth must be an integer.")
 
-            columns = ["timestamp"]
+            columns = ["symbol", "timestamp"]
             for i in range(depth):
                 columns.extend( [
                     "ask_px_" + str(i),
@@ -175,7 +175,7 @@ class KrackedDB:
             raise ValueError("Depth must be an integer.")
 
         # We need 4 SQL place holders for each depth level, and one for the timestamp.
-        placeholder = ["?"]*(depth*4+1)
+        placeholder = ["?"]*(depth*4+2)
 
         self.cur.execute(f"INSERT INTO L2 VALUES ({','.join(placeholder)})", l2_data)
 

--- a/kracked/db.py
+++ b/kracked/db.py
@@ -72,10 +72,10 @@ class KrackedDB:
                                 timestamp text,
                                 symbol text,
                                 bid numeric,
-                                bid_qty, numeric,
-                                ask, numeric,
+                                bid_qty numeric,
+                                ask numeric,
                                 ask_qty numeric,
-                                last, numeric,
+                                last numeric,
                                 volume numeric,
                                 vwap numeric,
                                 low numeric,
@@ -119,7 +119,7 @@ class KrackedDB:
                             """)
 
         elif table_name == "OHLC":
-
+            print('making OHLC table')
             self.cur.execute("""CREATE TABLE IF NOT EXISTS OHLC (
                                 timestamp text,
                                 symbol text,
@@ -147,7 +147,18 @@ class KrackedDB:
                                 trade_id numeric
             )""")
 
-    def write_L2(self, l2_data: List[Any], depth) -> None:
+    def write_L1(self, l1_data: List[Any]) -> None:
+        """
+        Write L1 data to the database.
+
+        Parameters
+        ----------
+        l1_data (List[Any]): The L1 data to write.
+        """ 
+
+        self.cur.executemany("INSERT INTO L1 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", l1_data)
+
+    def write_L2(self, l2_data: List[Any], depth: int) -> None:
 
         """
         Write L2 data to the database.
@@ -167,6 +178,7 @@ class KrackedDB:
         placeholder = ["?"]*(depth*4+1)
 
         self.cur.execute(f"INSERT INTO L2 VALUES ({','.join(placeholder)})", l2_data)
+
 
     def write_L3(self, l3_data: List[Any]) -> None:
 

--- a/kracked/feeds.py
+++ b/kracked/feeds.py
@@ -506,6 +506,10 @@ class KrakenL2(BaseKrakenWS):
                                         ) as fil:
                                             fil.write(",".join(line) + "\n")
                                 elif self.output_mode == "sql":
+
+                                    # When writing to the SQL database, we store all books in the same table, 
+                                    # so we need to add the symbol to the line.
+                                    line.insert(0, symbol)
                                     self.db.connect()
                                     self.db.write_L2(line, self.depth)
                                     self.db.safe_disconnect()

--- a/kracked/manager.py
+++ b/kracked/manager.py
@@ -58,6 +58,7 @@ class KrakenFeedManager:
             log_book_every = L2_params.get("log_book_every", 100)
             append_book = L2_params.get("append_book", True)
             depth = L2_params.get("depth", 10)
+            output_mode = L2_params.get("output_mode", "sql")
 
             self.L2 = KrakenL2(
                 symbols,
@@ -66,42 +67,48 @@ class KrakenFeedManager:
                 depth=depth,
                 log_book_every=log_book_every,
                 append_book=append_book,
+                output_mode=output_mode,
             )
             self.feeds["L2"] = self.L2
         if L3:
             print("KrakenFeedManager: Initializing L3 feed")
             log_ticks_every = L3_params.get("log_ticks_every", 100)
             log_for_webapp = L3_params.get("log_for_webapp", False)
+            output_mode = L3_params.get("output_mode", "sql")
             self.L3 = KrakenL3(
                 symbols,
                 api_key=self.api_key,
                 secret_key=self.api_secret,
                 trace=False,
                 log_ticks_every=log_ticks_every,
-                log_for_webapp=log_for_webapp,
                 output_directory=output_directory,
+                output_mode=output_mode
             )
             self.feeds["L3"] = self.L3
         if ohlc:
             print("KrakenFeedManager: Initializing OHLC feed")
             interval = ohlc_params.get("interval", 5)
             ccxt_snapshot = ohlc_params.get("ccxt_snapshot", False)
+            output_mode = ohlc_params.get("output_mode", "sql")
             self.ohlc = KrakenOHLC(
                 symbols,
                 trace=False,
                 output_directory=output_directory,
                 interval=interval,
                 ccxt_snapshot=ccxt_snapshot,
+                output_mode=output_mode
             )
             self.feeds["ohlc"] = self.ohlc
         if trades:
             print("KrakenFeedManager: Initializing Trades feed")
             log_trades_every = trades_params.get("log_trades_every", 100)
+            output_mode = trades_params.get("output_mode", "sql")
             self.trades = KrakenTrades(
                 symbols,
                 trace=False,
                 log_trades_every=log_trades_every,
                 output_directory=output_directory,
+                output_mode=output_mode
             )
             self.feeds["trades"] = self.trades
         if instruments:

--- a/kracked/utils.py
+++ b/kracked/utils.py
@@ -1,0 +1,196 @@
+
+
+multifeed_lines = """
+from kracked.manager import KrakenFeedManager
+import threading
+import toml, time
+
+# Load/type directly as arguments to the KrakenL3 constructor your API info.
+api_key = YOUR_API_KEY_HERE
+api_secret = YOUR_SECRET_KEY_HERE
+
+# Example of how to use the KrakenFeedManager to subscribe to multiple feeds.
+all_feeds = KrakenFeedManager(["DOGE/USD", "ETH/USD", "BTC/USD", "SOL/USD"],
+                              api_key,
+                              api_secret,
+                              L1=False,
+                              L2=True,
+                              L3=True,
+                              trades=True,
+                              ohlc=True,
+                              output_directory=".",
+
+                              L2_params={'log_book_every': 1},
+                              L3_params={'log_ticks_every': 1000},
+                              ohlc_params={'interval': 5,
+                                           'ccxt_snapshot': True},
+                              trades_params={'log_trades_every': 50}
+                              )
+
+# BEWARE if you use ccxt_snaphot, you get 720 historical candles, HOWEVER
+# they will not contain information about VWAP, TRADES, etc.
+
+# If you choose not to use ccxt for the historical data from Kraken, you will
+# only get 5 historical candlesticks.
+
+all_feeds.start_all()
+ct = 0
+try:
+
+    # Checks the status of all threads, restarts when/if they die.
+    while True:
+        ct += 1
+        time.sleep(1)
+
+        for name, thread in zip(all_feeds.threads.keys(),
+                                all_feeds.threads.values()):
+
+            if not thread.is_alive():
+                print(f"{name} Thread died, trying to restart")
+                curr_feed = all_feeds.feeds[name]
+                restarted_thread = threading.Thread(target=curr_feed.launch)
+                restarted_thread.daemon = True
+                restarted_thread.start()
+                all_feeds.threads[name] = restarted_thread
+                del thread
+
+except KeyboardInterrupt:
+    print("Shutting down feeds...")
+    all_feeds.stop_all()
+"""
+
+L1_lines = """
+from kracked.feeds import KrakenL1
+
+l1feed = KrakenL1(
+    "DOGE/USD",    # List or str of requested symbols.
+    output_directory=".",  # Output directory for L1 data files.
+    trace=False,                # Do not clog output with WS info. 
+)
+
+l1feed.launch()
+"""
+
+L2_lines = """
+from kracked.feeds import KrakenL2
+
+l2feed = KrakenL2(
+    ["DOGE/USD", "BTC/USD"],    # List or str of requested symbols.
+    # ["DOGE/USD"],    # List or str of requested symbols.
+    log_book_every=1,         # How often to log L2 book info.
+    append_book=True,           # Append book mode, saves historical L2 data.
+    output_directory=".",  # Output directory for L2 data files.
+    trace=False,                # Do not clog output with WS info.
+    output_mode="sql"
+)
+    
+l2feed.launch()                 # Launch the L2 data feed.
+"""
+
+L3_lines = """
+from kracked.feeds import KrakenL3
+import toml
+
+#api_key = YOUR_API_KEY
+#api_secret = YOUR_SECRET_KEY
+
+l3feed = KrakenL3(
+    ["DOGE/USD", "BTC/USD"],        # List or str of requested symbols.
+    api_key=api_key,                # Your API key for Kraken.
+    secret_key=api_secret,          # Your Secrete key for Kraken.
+    output_directory=".",          # Output directory for L3 data files.
+    trace=False,                    # Do not clog output with WS info.
+    output_mode="sql"
+)
+l3feed.launch()
+"""
+
+trades_lines = """
+from kracked.feeds import KrakenTrades
+
+tradefeed = KrakenTrades(
+    ["BTC/USD", "DOGE/USD"],    # List or str of requested symbols.
+    output_directory=".",  # Output directory for L1 data files.
+    # trace=False,                # Do not clog output with WS info.
+    # log_trades_every=1,         # How often 
+    log_trades_every=50,
+    output_mode="sql"
+)
+
+tradefeed.launch()
+"""
+
+ohlc_lines = """
+from kracked.feeds import KrakenOHLC
+
+ohlcfeed = KrakenOHLC(
+    # ["BTC/USD", "DOGE/USD"],# List or str of requested symbols.
+    ["DOGE/USD"],# List or str of requested symbols.
+    interval=5,             # Interval in minutes.
+    output_directory=".",# Output directory for L1 data files.
+    trace=False,            # Do not clog output with WS info.
+    ccxt_snapshot=True,     # Use the ccxt snapshot (you get more data)
+    output_mode="sql"
+)
+
+# BEWARE if you use ccxt_snaphot, you get 720 historical candles, HOWEVER
+# they will not contain information about VWAP, TRADES, etc.
+
+# If you choose not to use ccxt for the historical data from Kraken, you will
+# only get 5 historical candlesticks.
+
+ohlcfeed.launch()
+"""
+
+def get_multifeed_script() -> None:
+    """
+    Helper function to get example script for multifeed manager.
+    """
+    with open("multifeed_example_util.py", "w") as fil:
+        fil.write(multifeed_lines)
+
+def get_L1_script() -> None:
+    """
+    Helper function to get example script for L1 feed.
+    """
+    with open("L1_example_util.py", "w") as fil:
+        fil.write(L1_lines) 
+
+def get_L2_script() -> None:
+    """
+    Helper function to get example script for L2 feed.
+    """
+    with open("L2_example_util.py", "w") as fil:
+        fil.write(L2_lines)
+
+def get_L3_script() -> None:
+    """
+    Helper function to get example script for L3 feed.
+    """
+    with open("L3_example_util.py", "w") as fil:
+        fil.write(L3_lines)
+
+def get_trades_script() -> None:
+    """
+    Helper function to get example script for trades feed.
+    """
+    with open("trade_example_util.py", "w") as fil:
+        fil.write(trades_lines)
+
+def get_ohlc_script() -> None:
+    """
+    Helper function to get example script for OHLC feed.
+    """
+    with open("OHLC_example_util.py", "w") as fil:
+        fil.write(ohlc_lines)
+
+def get_all_scripts() -> None:
+    """
+    Helper function to get example scripts for all types of feeds.
+    """
+    get_multifeed_script()
+    get_L1_script()
+    get_L2_script()
+    get_L3_script()
+    get_trades_script()
+    get_ohlc_script()

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,257 @@
+from kracked.feeds import KrakenL1, KrakenL2, KrakenL3
+from kracked.feeds import KrakenTrades, KrakenOHLC
+
+import sqlite3
+
+import warnings
+warnings.filterwarnings("ignore")
+
+import threading
+import toml
+import inspect
+import time
+import os
+
+with open("/home/alg/.api.toml", "r") as fil:
+    data = toml.load(fil)
+api_key = data['kraken_api']
+api_secret = data['kraken_sec']
+
+if os.path.exists("data"):
+    os.system("rm -r data/*")
+    os.rmdir("data")
+    os.mkdir("data")
+
+def test_sql_trades():
+    """
+    Tests the SQL output mode of the Trades feed.
+    """
+
+    # Instance the KrakenTrades object.
+    tradefeed = KrakenTrades(
+        ["BTC/USD", "DOGE/USD", "ETH/USD"],    # List or str of requested symbols.
+        output_directory="data",  # Output directory for L1 data files.
+        # trace=False,                # Do not clog output with WS info.
+        # log_trades_every=1,         # How often 
+        log_trades_every=4,
+        output_mode="sql",
+    )
+
+    # Start a background process with the KrakenTrades object.
+    thread = threading.Thread(target=tradefeed.launch)
+    thread.daemon = True
+    thread.start()
+
+    # Give it enough time to pull some data/store in the SQL database.
+    time.sleep(3)
+
+    # Stop the background process.
+    tradefeed.stop_websocket()
+
+    # Connect to the database and grab a cursor.
+    conn = sqlite3.connect("data/kracked_outputs.db")
+    cur = conn.cursor()
+
+    # Check the table exists.
+    res = cur.execute("SELECT name from sqlite_master where type='table'")
+    table_names = [v[0] for v in res.fetchall()]
+    assert "trades" in table_names , "trades table not created"
+
+    # Check the table contains all the proper columns.
+    res = cur.execute("PRAGMA table_info(trades)")
+    column_names = [r[1] for r in res.fetchall()]
+
+    assert column_names == ['ts_event', 'symbol', 'price', 'qty', 'side', 'ord_type', 'trade_id'] , "Columns invalid in trade table"
+
+
+def test_ohlc_sql():
+    """
+    Tests the SQL output mode for the OHLC candlesticks.
+    """
+
+    # Spin up the KrakenOHLC object.
+    ohlcfeed = KrakenOHLC(
+        ["DOGE/USD"],               # List or str of requested symbols.
+        interval=1,                 # Interval in minutes.
+        output_directory="data",    # Output directory for L1 data files.
+        ccxt_snapshot=True,         # Use the ccxt snapshot (you get more data)
+        output_mode="sql",
+    )
+
+    # Start up a daemon process for the websocket/CCXT snapshot.    
+    thread = threading.Thread(target=ohlcfeed.launch)
+    thread.daemon = True
+    thread.start()
+
+    # Give it enough time to pull data.
+    time.sleep(5)
+
+    # Stop the background process
+    ohlcfeed.stop_websocket()
+
+    # Connect to the database and grab a cursor.
+    conn = sqlite3.connect("data/kracked_outputs.db")
+    cur = conn.cursor()
+
+    # Check the table xists.
+    res = cur.execute("SELECT name from sqlite_master where type='table'")
+    table_names = [v[0] for v in res.fetchall()]
+    assert "OHLC" in table_names, "OHLC table not created"
+
+    # Check the table contains all the proper columns
+    res = cur.execute("PRAGMA table_info(OHLC)")
+    column_names = [r[1] for r in res.fetchall()]
+    assert column_names == ['timestamp', 'symbol', 'open',
+                            'high', 'low', 'close',
+                            'volume', 'vwap', 'trades',
+                            'tstart', 'ttrue'] , "Columns in OHLC table are not correct."
+
+
+
+
+
+
+# L3 needs API auth, so let's just not include this in the test suite (except for those who are
+# motivated enough to modify this file and implement :p)
+# def test_sql_L3():
+#     l3feed = KrakenL3(
+#         ["DOGE/USD", "BTC/USD"],        # List or str of requested symbols.
+#         api_key=api_key,                # Your API key for Kraken.
+#         secret_key=api_secret,          # Your Secrete key for Kraken.
+#         output_directory='data',          # Output directory for L3 data files.
+#         trace=False,                    # Do not clog output with WS info.
+#         output_mode="sql",
+#     )
+#     l3feed.launch()
+
+def test_sql_L1():
+    """
+    Tests the SQL output mode for the L1 trades.
+    """
+
+    # Spin up the KrakenTrades object.
+    l1feed = KrakenL1(
+        ["DOGE/USD", "BTC/USD"],    # List or str of requested symbols.
+        output_directory="data",  # Output directory for L1 data files.
+        output_mode="sql",
+    )
+
+
+    # Start up a daemon process for the websocket/CCXT snapshot.    
+    thread = threading.Thread(target=l1feed.launch)
+    thread.daemon=True
+    thread.start()
+
+    # Give it enough time to pull some data/store in the SQL database.
+    time.sleep(5)
+
+    # Stop the background process.
+    l1feed.stop_websocket()
+
+    # Connect to the database and grab a cursor.
+    conn = sqlite3.connect("data/kracked_outputs.db")
+    cur = conn.cursor()
+
+    # Check the table exists.
+    res = cur.execute("SELECT name from sqlite_master where type='table'")
+    table_names = [v[0] for v in res.fetchall()]
+    assert "L1" in table_names, "L1 table not created"
+
+    # Check the table contains all the proper columns.
+    res = cur.execute("PRAGMA table_info(L1)")
+    column_names = [r[1] for r in res.fetchall()]
+
+    assert column_names == ['timestamp', 'symbol', 'bid',
+                            'bid_qty', 'ask', 'ask_qty',
+                            'last', 'volume', 'vwap',
+                            'low', 'high', 'change',
+                            'change_pct'] , "Columns in L1 table are not correct."    
+
+
+def test_sql_L2():
+    """
+    Tests the SQL output mode for the L2 orderbook.
+    """
+
+    # Spin up the KrakenL2 object.
+    l2feed = KrakenL2(
+        ["DOGE/USD", "BTC/USD"],    # List or str of requested symbols.
+        # ["DOGE/USD"],    # List or str of requested symbols.
+    log_book_every=1,         # How often to log L2 book info.
+    append_book=True,           # Append book mode, saves historical L2 data.
+    output_directory="data",  # Output directory for L2 data files.
+    trace=False,                # Do not clog output with WS info.
+    output_mode="sql"
+    )
+
+
+    # Start a background process with the KrakenL2 object.
+    thread = threading.Thread(target=l2feed.launch)        
+    thread.daemon=True
+    thread.start()
+
+    # Give it enough time to pull some data/store in the SQL database.
+    time.sleep(5)
+
+    # Stop the background process.
+    l2feed.stop_websocket()
+
+    # Connect to the database and grab a cursor.
+    conn = sqlite3.connect("data/kracked_outputs.db")
+    cur = conn.cursor()
+
+    res = cur.execute("SELECT name from sqlite_master where type='table'")
+
+    table_names = [v[0] for v in res.fetchall()]
+
+    assert "L2" in table_names, "L2 table not created"
+
+    res = cur.execute("PRAGMA table_info(L2)")
+    column_names = [r[1] for r in res.fetchall()]
+
+    assert column_names == ['timestamp',
+                            'ask_px_0',
+                            'ask_sz_0',
+                            'bid_px_0',
+                            'bid_sz_0',
+                            'ask_px_1',
+                            'ask_sz_1',
+                            'bid_px_1',
+                            'bid_sz_1',
+                            'ask_px_2',
+                            'ask_sz_2',
+                            'bid_px_2',
+                            'bid_sz_2',
+                            'ask_px_3',
+                            'ask_sz_3',
+                            'bid_px_3',
+                            'bid_sz_3',
+                            'ask_px_4',
+                            'ask_sz_4',
+                            'bid_px_4',
+                            'bid_sz_4',
+                            'ask_px_5',
+                            'ask_sz_5',
+                            'bid_px_5',
+                            'bid_sz_5',
+                            'ask_px_6',
+                            'ask_sz_6',
+                            'bid_px_6',
+                            'bid_sz_6',
+                            'ask_px_7',
+                            'ask_sz_7',
+                            'bid_px_7',
+                            'bid_sz_7',
+                            'ask_px_8',
+                            'ask_sz_8',
+                            'bid_px_8',
+                            'bid_sz_8',
+                            'ask_px_9',
+                            'ask_sz_9',
+                            'bid_px_9',
+                            'bid_sz_9'] , "Column names not correct in L2 table."
+
+
+
+
+


### PR DESCRIPTION
Add SQL database support. This is currently for sqlite3, but I have working MySQL/AWS integration as well with RDS (and one could easily do this on S3). I won't get around to pushing the MySQL changes for a while, but if you need this in advance feel free to reach out to me.


This PR does the following:

1. Add SQL support (and change default behavior) for all relevant feeds.
2. Add a utils.py file that allows one to generate example scripts (this is for the pip release).
3. Tests for the SQL functionality added. 